### PR TITLE
Use NG promises behind an ES6 Promise like API

### DIFF
--- a/karma.conf.babel.js
+++ b/karma.conf.babel.js
@@ -6,6 +6,8 @@ var babelOptions = require('./config').babel;
 module.exports = function(config) {
 
   config.set({
+    browserNoActivityTimeout: 20000,
+
     frameworks: ['jasmine', 'browserify'],
 
     files: [

--- a/src/relayer.js
+++ b/src/relayer.js
@@ -13,6 +13,7 @@ import ResourceBuilder from "./relayer/ResourceBuilder.js";
 import Transport from "./relayer/Transport.js";
 import UrlHelper from "./relayer/UrlHelper.js";
 import * as TemplatedUrls from "./relayer/TemplatedUrl.js";
+import RelayerPromiseFactory from "./relayer/Promise.js";
 import {AsModule, Provider} from "a1atscript";
 import Inflector from "xing-inflector";
 
@@ -34,7 +35,8 @@ import Inflector from "xing-inflector";
   InitializedResourceClasses,
   ResourceBuilder,
   PrimaryResourceBuilder,
-  Inflector
+  Inflector,
+  RelayerPromiseFactory
 ])
 @Provider('relayer', ['$provide'])
 export default class ResourceLayer {

--- a/src/relayer/Promise.js
+++ b/src/relayer/Promise.js
@@ -1,0 +1,38 @@
+import {Factory} from "a1atscript";
+
+class RelayerPromise {
+
+  static resolve(value) {
+    return new RelayerPromise((res, rej) => res(value));
+  }
+
+  static reject(value) {
+    return new RelayerPromise((res, rej) => rej(value));
+  };
+
+  constructor(resolver) {
+    this.internalPromise = RelayerPromiseFactory.$q(resolver);
+  }
+
+  then(onFulfilled, onRejected, progressBack) {
+    return this.internalPromise.then(onFulfilled, onRejected, progressBack);
+  }
+
+  catch(callback) {
+    return this.internalPromise.catch(callback);
+  }
+
+  finally(callback, progressBack) {
+    return this.internalPromise.finally(callback, progressBack);
+  }
+}
+
+export default class RelayerPromiseFactory {
+
+  @Factory('RelayerPromise', ['$q'])
+  static factory($q) {
+    RelayerPromiseFactory.$q = $q;
+    return RelayerPromise;
+  }
+
+}

--- a/src/relayer/endpoints/LoadedDataEndpoint.js
+++ b/src/relayer/endpoints/LoadedDataEndpoint.js
@@ -1,20 +1,21 @@
 import ResolvedEndpoint from "./ResolvedEndpoint.js";
 import {SimpleFactory} from "../SimpleFactoryInjector.js";
 
-@SimpleFactory('LoadedDataEndpointFactory')
+@SimpleFactory('LoadedDataEndpointFactory', ['RelayerPromise'])
 export default class LoadedDataEndpoint extends ResolvedEndpoint {
 
-  constructor(resolvedEndpoint, resource, resourceTransformers = [], createResourceTransformers = []) {
-    super(resolvedEndpoint.transport,
+  constructor(Promise, resolvedEndpoint, resource, resourceTransformers = [], createResourceTransformers = []) {
+    super(Promise, resolvedEndpoint.transport,
       resolvedEndpoint.templatedUrl,
       resolvedEndpoint.resourceTransformers.concat(resourceTransformers),
       resolvedEndpoint.createResourceTransformers.concat(createResourceTransformers));
     this.resource = resource;
+    this.Promise = Promise;
     this.data = resolvedEndpoint._transformRequest(resolvedEndpoint.resourceTransformers, resource);
   }
 
   _load() {
-    return this._transformResponse(this.resourceTransformers, Promise.resolve({
+    return this._transformResponse(this.resourceTransformers, this.Promise.resolve({
       data: this.data, etag: this.templatedUrl.etag}));
   }
 

--- a/src/relayer/endpoints/ResolvedEndpoint.js
+++ b/src/relayer/endpoints/ResolvedEndpoint.js
@@ -1,9 +1,9 @@
 import Endpoint from "./Endpoint.js";
 import {SimpleFactory} from "../SimpleFactoryInjector.js";
 
-@SimpleFactory('ResolvedEndpointFactory')
+@SimpleFactory('ResolvedEndpointFactory', ["RelayerPromise"])
 export default class ResolvedEndpoint extends Endpoint {
-  constructor(transport, templatedUrl, resourceTransformers = [], createResourceTransformers = []) {
+  constructor(Promise, transport, templatedUrl, resourceTransformers = [], createResourceTransformers = []) {
     super();
     this.transport = transport;
     this.templatedUrl = templatedUrl;

--- a/test/LoadedDataEndpoint.js
+++ b/test/LoadedDataEndpoint.js
@@ -97,8 +97,8 @@ describe("LoadedDataEndpoint", function() {
     resourceTransformerRequestSpy = spyOn(dataResourceTransformer, "transformRequest").and.callThrough();
     resourceTransformerResponseSpy = spyOn(dataResourceTransformer, "transformResponse").and.callThrough();
 
-    resolvedEndpoint = new ResolvedEndpoint(transport, templatedUrl, initialResourceTransformer, createResourceTransformer)
-    loadedDataEndpoint = new LoadedDataEndpoint(resolvedEndpoint, { wrapped: mockData }, dataResourceTransformer)
+    resolvedEndpoint = new ResolvedEndpoint(Promise, transport, templatedUrl, initialResourceTransformer, createResourceTransformer)
+    loadedDataEndpoint = new LoadedDataEndpoint(Promise, resolvedEndpoint, { wrapped: mockData }, dataResourceTransformer)
 
   });
 

--- a/test/Promise.js
+++ b/test/Promise.js
@@ -1,0 +1,71 @@
+import RelayerPromiseFactory from "../src/relayer/Promise.js";
+
+describe("Relayer Promise", function() {
+  var relayerPromise, RelayerPromise, promiseImplementation, finalResults;
+  beforeEach(function() {
+    promiseImplementation = function(...params) {
+      return new Promise(...params);
+    };
+
+    RelayerPromise = RelayerPromiseFactory.factory(promiseImplementation);
+  });
+
+  describe("constructor style", function() {
+    describe("resolve", function() {
+      beforeEach(function(done) {
+        relayerPromise = new RelayerPromise((res, rej) => res("Hello"));
+        relayerPromise.then((results) => {
+          finalResults = results;
+          done();
+        });
+      });
+
+      it("should resolve", function() {
+        expect(finalResults).toEqual("Hello");
+      });
+    });
+
+    describe("reject", function() {
+      beforeEach(function(done) {
+        relayerPromise = new RelayerPromise((res, rej) => rej("Fail"));
+        relayerPromise.catch((results) => {
+          finalResults = results;
+          done();
+        });
+      });
+
+      it("should resolve", function() {
+        expect(finalResults).toEqual("Fail");
+      });
+    });
+
+  });
+
+  describe("resolve", function() {
+    beforeEach(function(done) {
+      relayerPromise = RelayerPromise.resolve("Hello");
+      relayerPromise.then((results) => {
+        finalResults = results;
+        done();
+      });
+    });
+
+    it("should resolve", function() {
+      expect(finalResults).toEqual("Hello");
+    });
+  });
+
+  describe("reject", function() {
+    beforeEach(function(done) {
+      relayerPromise = RelayerPromise.reject("Fail");
+      relayerPromise.catch((results) => {
+        finalResults = results;
+        done();
+      });
+    });
+
+    it("should resolve", function() {
+      expect(finalResults).toEqual("Fail");
+    });
+  });
+});

--- a/test/PromiseEndpoint.js
+++ b/test/PromiseEndpoint.js
@@ -77,7 +77,7 @@ describe("PromiseEndpoint", function() {
     resourceTransformerRequestSpy = spyOn(resourceTransformer, "transformRequest").and.callThrough();
     resourceTransformerResponseSpy = spyOn(resourceTransformer, "transformResponse").and.callThrough();
 
-    resolvedEndpoint = new ResolvedEndpoint(transport, templatedUrl, resourceTransformer, createResourceTransformer)
+    resolvedEndpoint = new ResolvedEndpoint(Promise, transport, templatedUrl, resourceTransformer, createResourceTransformer)
     promiseEndpoint = new PromiseEndpoint(Promise.resolve(resolvedEndpoint));
 
   });

--- a/test/ResolvedEndpoint.js
+++ b/test/ResolvedEndpoint.js
@@ -76,7 +76,7 @@ describe("Endpoint", function() {
     resourceTransformerRequestSpy = spyOn(resourceTransformer, "transformRequest").and.callThrough();
     resourceTransformerResponseSpy = spyOn(resourceTransformer, "transformResponse").and.callThrough();
 
-    resolvedEndpoint = new ResolvedEndpoint(transport, templatedUrl, resourceTransformer, createResourceTransformer)
+    resolvedEndpoint = new ResolvedEndpoint(Promise, transport, templatedUrl, resourceTransformer, createResourceTransformer)
 
   });
 

--- a/test/integration/PageTest.js
+++ b/test/integration/PageTest.js
@@ -135,7 +135,7 @@ var AppModule = new Module("AppModule", [RL, AppConfig.prototype]);
 
 describe("Page test", function() {
 
-  var mockHttp, resources;
+  var mockHttp, resources, $rootScope;
 
   beforeEach(function() {
     function pageData() {
@@ -186,7 +186,7 @@ describe("Page test", function() {
       }
     }
 
-    mockHttp = function(params) {
+    mockHttp = function(Promise, params) {
       if (params.method == "GET" && params.url == "http://www.example.com/resources") {
         return Promise.resolve({
           status: 200,
@@ -247,10 +247,15 @@ describe("Page test", function() {
     injector.instantiate(AppModule);
     angular.mock.module('AppModule');
     angular.mock.module(function($provide) {
-      $provide.value("$http", mockHttp);
+      $provide.factory("$http", function(RelayerPromise) {
+        return function(params) {
+          return mockHttp(RelayerPromise, params);
+        };
+      });
     });
-    inject(function(_resources_) {
+    inject(function(_resources_, _$rootScope_) {
       resources = _resources_;
+      $rootScope = _$rootScope_;
     });
   })
 
@@ -259,6 +264,7 @@ describe("Page test", function() {
 
     beforeEach(function() {
       page = resources.pages().new();
+
     });
 
     it('should have defined values on all getters', function() {
@@ -327,6 +333,7 @@ describe("Page test", function() {
         page = createdPage;
         done();
       });
+      $rootScope.$apply();
     });
 
     it('should have a title', function() {

--- a/test/integration/RelationshipsTest.js
+++ b/test/integration/RelationshipsTest.js
@@ -96,14 +96,14 @@ describe("initialization", function() {
 });
 
 describe("Loading relationships test", function() {
-  var resources, book, act, chapter, chapters, section, paragraph, character, $httpBackend;
+  var resources, book, act, chapter, chapters, section, paragraph, character, $httpBackend, $rootScope;
 
   beforeEach(function () {
     var injector = new Injector();
     injector.instantiate(AppModule);
     angular.mock.module('AppModule');
 
-    var mockHttp = function(params) {
+    var mockHttp = function(Promise, params) {
       if (params.url == "http://www.example.com/resources") {
         return Promise.resolve({
           status: 200,
@@ -299,10 +299,15 @@ describe("Loading relationships test", function() {
       }
     }
     angular.mock.module(function($provide) {
-      $provide.value("$http", mockHttp);
+      $provide.factory("$http", function(RelayerPromise) {
+        return function(params) {
+          return mockHttp(RelayerPromise, params);
+        };
+      });
     });
-    inject(function($injector, _resources_) {
+    inject(function($injector, _resources_, _$rootScope_) {
       resources = _resources_;
+      $rootScope = _$rootScope_;
     });
   });
 
@@ -315,6 +320,7 @@ describe("Loading relationships test", function() {
         book = _book_;
         done();
       });
+      $rootScope.$apply();
     });
 
     it("should resolve the book", function() {


### PR DESCRIPTION
For the time being I am getting unpredictable resolution of promises because we're using ES6 Promises instead of Angular's $q.  This switches Relayer to $q, but puts it behind an abstracted promise API so we can easily switch back later if a better resolution is found.
