### PR TITLE
Add utilities functions class

### DIFF
--- a/src/relayer.js
+++ b/src/relayer.js
@@ -14,6 +14,7 @@ import Transport from "./relayer/Transport.js";
 import UrlHelper from "./relayer/UrlHelper.js";
 import * as TemplatedUrls from "./relayer/TemplatedUrl.js";
 import RelayerPromiseFactory from "./relayer/Promise.js";
+import RelationshipUtilities from "./relayer/RelationshipUtilities.js";
 import {AsModule, Provider} from "a1atscript";
 import Inflector from "xing-inflector";
 
@@ -36,7 +37,8 @@ import Inflector from "xing-inflector";
   ResourceBuilder,
   PrimaryResourceBuilder,
   Inflector,
-  RelayerPromiseFactory
+  RelayerPromiseFactory,
+  RelationshipUtilities
 ])
 @Provider('relayer', ['$provide'])
 export default class ResourceLayer {

--- a/src/relayer/RelationshipUtilities.js
+++ b/src/relayer/RelationshipUtilities.js
@@ -11,18 +11,17 @@ export default class RelationshipUtilities {
       return resource.relationships[name] ? true : false;
     }
     target.set = function(newRelationship) {
+      var linksPath = resource.constructor.relationships[name].linksPath;
       if (resource.relationships[name] instanceof TemplatedUrl) {
-        var linksPath = resource.constructor.relationships[name].linksPath;
         resource.relationships[name].removeDataPathLink(resource, linksPath);
-        resource.relationships[name] = newRelationship;
-        if (newRelationship) {
-          newRelationship.addDataPathLink(resource, linksPath, false);
-        } else {
+        if (!newRelationship) {
           resource.pathSet(linksPath, "");
         }
-      } else {
-        resource.relationships[name] = newRelationship;
       }
+      if (newRelationship instanceof TemplatedUrl) {
+        newRelationship.addDataPathLink(resource, linksPath, false);
+      }
+      resource.relationships[name] = newRelationship;
     }
   }
 }

--- a/src/relayer/RelationshipUtilities.js
+++ b/src/relayer/RelationshipUtilities.js
@@ -22,6 +22,9 @@ export default class RelationshipUtilities {
         newRelationship.addDataPathLink(resource, linksPath, false);
       }
       resource.relationships[name] = newRelationship;
+      if (!resource.relationships[name]) {
+        delete resource.relationships[name];
+      }
     }
   }
 }

--- a/src/relayer/RelationshipUtilities.js
+++ b/src/relayer/RelationshipUtilities.js
@@ -1,0 +1,28 @@
+import {Service} from "a1atscript";
+import {TemplatedUrl} from "./TemplatedUrl.js";
+
+@Service('RelationshipUtilities')
+export default class RelationshipUtilities {
+  addMethods(target, resource, name) {
+    target.get = function() {
+      return resource.relationships[name];
+    };
+    target.present = function() {
+      return resource.relationships[name] ? true : false;
+    }
+    target.set = function(newRelationship) {
+      if (resource.relationships[name] instanceof TemplatedUrl) {
+        var linksPath = resource.constructor.relationships[name].linksPath;
+        resource.relationships[name].removeDataPathLink(resource, linksPath);
+        resource.relationships[name] = newRelationship;
+        if (newRelationship) {
+          newRelationship.addDataPathLink(resource, linksPath, false);
+        } else {
+          resource.pathSet(linksPath, "");
+        }
+      } else {
+        resource.relationships[name] = newRelationship;
+      }
+    }
+  }
+}

--- a/src/relayer/TemplatedUrl.js
+++ b/src/relayer/TemplatedUrl.js
@@ -26,18 +26,27 @@ export class TemplatedUrl {
     this._uriParams = uriParams;
   }
 
-  addDataPathLink(resource, path) {
-    var newUrl = resource.pathGet(path);
-    if (newUrl) {
-      this._setUrl(newUrl);
-      this._paths.forEach((path) => {
-        path.resource.pathSet(path.path, newUrl);
-      });
-      this._paths.push({
-        resource: resource,
-        path: path
-      });
+  addDataPathLink(resource, path, overwrite = true) {
+
+    if (overwrite) {
+      var newUrl = resource.pathGet(path);
+      if (newUrl) {
+        this._setUrl(newUrl);
+        this._paths.forEach((path) => {
+          path.resource.pathSet(path.path, newUrl);
+        });
+      }
+    } else {
+      resource.pathSet(path, this.url);
     }
+    this._paths.push({
+      resource: resource,
+      path: path
+    });
+  }
+
+  removeDataPathLink(resource, path) {
+    this._paths = this._paths.filter((pathLink) => (pathLink.resource != resource) || (pathLink.path != path));
   }
 }
 

--- a/src/relayer/decorators/RelatedResourceDecorator.js
+++ b/src/relayer/decorators/RelatedResourceDecorator.js
@@ -2,13 +2,14 @@ import ResourceDecorator from "./ResourceDecorator.js"
 import {TemplatedUrl} from "../TemplatedUrl.js"
 import {SimpleFactory} from "../SimpleFactoryInjector.js"
 
-@SimpleFactory("RelatedResourceDecoratorFactory", ['PromiseEndpointFactory'])
+@SimpleFactory("RelatedResourceDecoratorFactory", ['PromiseEndpointFactory', 'RelationshipUtilities'])
 export default class RelatedResourceDecorator extends ResourceDecorator {
 
-  constructor(promiseEndpointFactory, name, relationship){
+  constructor(promiseEndpointFactory, relationshipUtilities, name, relationship){
     super(name);
 
     this.promiseEndpointFactory = promiseEndpointFactory;
+    this.relationshipUtilities = relationshipUtilities;
     this.relationship = relationship;
   }
 
@@ -17,6 +18,7 @@ export default class RelatedResourceDecorator extends ResourceDecorator {
       var name = this.name;
       var relationship = this.relationship;
       var promiseEndpointFactory = this.promiseEndpointFactory;
+      var relationshipUtilities = this.relationshipUtilities;
       this._resourceFn = function(uriParams, recursiveCall = false) {
         if (relationship.async && this.isPersisted) {
           var endpoint;
@@ -34,6 +36,7 @@ export default class RelatedResourceDecorator extends ResourceDecorator {
             endpoint = relationship.embeddedEndpoint(this, uriParams);
           }
           relationship.ResourceClass.resourceDescription.applyToEndpoint(endpoint);
+          relationshipUtilities.addMethods(endpoint, this, name);
           return endpoint;
         } else {
           if (this.relationships[name] instanceof TemplatedUrl) {

--- a/test/RelationshipUtilities.js
+++ b/test/RelationshipUtilities.js
@@ -82,7 +82,7 @@ describe("RelationshipUtilities", function() {
         target.set(undefined);
         initialTemplatedUrl.addDataPathLink(otherResource, "$.links.cheese");
         expect(initialTemplatedUrl.url).toEqual("/cheese/5")
-        expect(resource.relationships[name]).toEqual(undefined);
+        expect(Object.keys(resource.relationships)).not.toContain(name);
         expect(resource.pathGet('$.links.cheese')).toEqual("");
       });
 

--- a/test/RelationshipUtilities.js
+++ b/test/RelationshipUtilities.js
@@ -10,7 +10,9 @@ describe("RelationshipUtilities", function() {
 
   beforeEach(function() {
     resource = new Something({ data: {}, links: { cheese: ""}});
-
+    Something.relationships[name] = {
+      linksPath: "$.links.cheese"
+    }
     target = {};
 
     name = "cheese";
@@ -60,9 +62,6 @@ describe("RelationshipUtilities", function() {
     describe("for template url", function() {
       var initialTemplatedUrl, newTemplatedUrl, otherResource;
       beforeEach(function() {
-        Something.relationships[name] = {
-          linksPath: "$.links.cheese"
-        }
         otherResource = new Something({data: {}, links: { cheese: "/cheese/5"}});
         initialTemplatedUrl = new TemplatedUrlFromUrl("/cheese/{cheese}", "/cheese/4");
         resource.relationships[name] = initialTemplatedUrl;
@@ -85,6 +84,20 @@ describe("RelationshipUtilities", function() {
         expect(initialTemplatedUrl.url).toEqual("/cheese/5")
         expect(resource.relationships[name]).toEqual(undefined);
         expect(resource.pathGet('$.links.cheese')).toEqual("");
+      });
+
+    });
+
+    describe("nothing to template url", function() {
+      var newTemplatedUrl;
+      beforeEach(function() {
+        newTemplatedUrl = new TemplatedUrlFromUrl("/baggins/{name}", "/baggins/bilbo");
+      });
+
+      it("on reassignment it should connect to new url", function() {
+        target.set(newTemplatedUrl);
+        expect(resource.relationships[name]).toEqual(newTemplatedUrl);
+        expect(resource.pathGet('$.links.cheese')).toEqual("/baggins/bilbo");
       });
     });
 

--- a/test/RelationshipUtilities.js
+++ b/test/RelationshipUtilities.js
@@ -1,0 +1,103 @@
+import RelationshipUtilities from "../src/relayer/RelationshipUtilities.js";
+import {TemplatedUrlFromUrl} from "../src/relayer/TemplatedUrl.js";
+import Resource from "../src/relayer/Resource.js";
+
+class Something extends Resource {
+
+}
+describe("RelationshipUtilities", function() {
+  var relationshipUtilities, resource, target, name;
+
+  beforeEach(function() {
+    resource = new Something({ data: {}, links: { cheese: ""}});
+
+    target = {};
+
+    name = "cheese";
+
+    relationshipUtilities = new RelationshipUtilities();
+  });
+
+  describe("get", function() {
+    beforeEach(function() {
+      resource.relationships[name] = "Here's the cheese";
+      relationshipUtilities.addMethods(target, resource, name);
+    });
+
+    it("should return the relationship", function() {
+      expect(target.get()).toEqual("Here's the cheese");
+    });
+  });
+
+  describe("present", function() {
+    describe ("when present", function() {
+      beforeEach(function() {
+        resource.relationships[name] = "Here's the cheese";
+        relationshipUtilities.addMethods(target, resource, name);
+      });
+
+      it("should be present", function() {
+        expect(target.present()).toBe(true);
+      });
+    });
+
+    describe ("when not present", function() {
+      beforeEach(function() {
+        relationshipUtilities.addMethods(target, resource, name);
+      });
+
+      it("should be present", function() {
+        expect(target.present()).toBe(false);
+      });
+    });
+  });
+
+  describe("set", function() {
+    beforeEach(function() {
+      relationshipUtilities.addMethods(target, resource, name);
+    });
+
+    describe("for template url", function() {
+      var initialTemplatedUrl, newTemplatedUrl, otherResource;
+      beforeEach(function() {
+        Something.relationships[name] = {
+          linksPath: "$.links.cheese"
+        }
+        otherResource = new Something({data: {}, links: { cheese: "/cheese/5"}});
+        initialTemplatedUrl = new TemplatedUrlFromUrl("/cheese/{cheese}", "/cheese/4");
+        resource.relationships[name] = initialTemplatedUrl;
+        initialTemplatedUrl.addDataPathLink(resource, "$.links.cheese", false);
+        newTemplatedUrl = new TemplatedUrlFromUrl("/baggins/{name}", "/baggins/bilbo");
+      });
+
+      it("on reassignment it should disconnect the previous template url and connect to new url", function() {
+        expect(resource.pathGet('$.links.cheese')).toEqual("/cheese/4");
+        target.set(newTemplatedUrl);
+        initialTemplatedUrl.addDataPathLink(otherResource, "$.links.cheese");
+        expect(initialTemplatedUrl.url).toEqual("/cheese/5")
+        expect(resource.relationships[name]).toEqual(newTemplatedUrl);
+        expect(resource.pathGet('$.links.cheese')).toEqual("/baggins/bilbo");
+      });
+
+      it("on reassignment to empty it should set the link blank and disconnect", function() {
+        target.set(undefined);
+        initialTemplatedUrl.addDataPathLink(otherResource, "$.links.cheese");
+        expect(initialTemplatedUrl.url).toEqual("/cheese/5")
+        expect(resource.relationships[name]).toEqual(undefined);
+        expect(resource.pathGet('$.links.cheese')).toEqual("");
+      });
+    });
+
+    describe("for everything else", function() {
+      beforeEach(function() {
+        resource.relationships[name] = "awesome";
+      });
+
+      it("should simply reassign the relationship", function() {
+        target.set("bogus");
+        expect(resource.relationships[name]).toEqual("bogus")
+      });
+    });
+  });
+
+})

--- a/test/TemplatedUrl.js
+++ b/test/TemplatedUrl.js
@@ -99,6 +99,48 @@ describe("TemplatedUrl", function() {
       templatedUrl.addDataPathLink(mockResource, "$.links.self");
       expect(mockOtherResource.links.cheese).toEqual("/cheese/5")
     });
+
+    it("when I add with no overwrite", function() {
+      templatedUrl.addDataPathLink(mockOtherResource, "$.links.cheese")
+      templatedUrl.addDataPathLink(mockResource, "$.links.self", false);
+      expect(mockResource.links.self).toEqual("/cheese/4");
+      expect(mockOtherResource.links.cheese).toEqual("/cheese/4");
+    });
+
+    describe("removeDataPathLink", function() {
+      var mockFinalResource;
+
+      beforeEach(function() {
+        mockFinalResource = {
+          links: {
+            thing: "/cheese/6"
+          },
+
+          pathGet(param) {
+            if (param === "$.links.thing") {
+              return this.links.thing;
+            }
+          },
+
+          pathSet(param, value) {
+            if (param === "$.links.thing") {
+              this.links.thing = value
+            }
+          }
+        }
+        templatedUrl.addDataPathLink(mockOtherResource, "$.links.cheese")
+        templatedUrl.addDataPathLink(mockResource, "$.links.self");
+      });
+
+      it("when I remove a data path link it should no longer get updated by additional writes", function() {
+        expect(mockOtherResource.links.cheese).toEqual("/cheese/5");
+        expect(mockResource.links.self).toEqual("/cheese/5");
+        templatedUrl.removeDataPathLink(mockOtherResource, "$.links.cheese");
+        templatedUrl.addDataPathLink(mockFinalResource, "$.links.thing");
+        expect(mockResource.links.self).toEqual("/cheese/6");
+        expect(mockOtherResource.links.cheese).toEqual("/cheese/5")
+      });
+    });
   });
 
 });

--- a/test/decorators/RelatedResourceDecorator.js
+++ b/test/decorators/RelatedResourceDecorator.js
@@ -3,6 +3,7 @@ import {TemplatedUrl} from "../../src/relayer/TemplatedUrl.js";
 
 describe("RelatedResourceDecorator", function() {
   var promiseEndpointFactory,
+  relationshipUtilities,
   name,
   relationship,
   OtherResourceClass,
@@ -70,7 +71,14 @@ describe("RelatedResourceDecorator", function() {
       }
     }
 
+    relationshipUtilities = {
+      addMethods(target, resource, name) {
+        target.awesome = "set it awesome";
+      }
+    }
+
     relatedResourceDecorator = new RelatedResourceDecorator(promiseEndpointFactory,
+      relationshipUtilities,
       name,
       relationship);
   });
@@ -93,13 +101,13 @@ describe("RelatedResourceDecorator", function() {
           expect(resource.awesome("cheese")).toEqual({
             thisResource: resource,
             uriParams: "cheese",
-            applied: true
+            applied: true,
+            awesome: "set it awesome"
           })
         });
 
-        it("the endpoint should be embedded", function() {
-          resource.awesome("cheese");
-          expect(embeddedEndpointSpy).toHaveBeenCalled();
+        it("should setup utility methods", function() {
+          expect(resource.awesome)
         })
       });
       describe("linked", function() {
@@ -116,7 +124,8 @@ describe("RelatedResourceDecorator", function() {
           expect(resource.awesome("cheese")).toEqual({
             thisResource: resource,
             uriParams: "cheese",
-            applied: true
+            applied: true,
+            awesome: "set it awesome"
           })
         });
 
@@ -142,7 +151,8 @@ describe("RelatedResourceDecorator", function() {
 
           it("should setup the right endpoint", function() {
             expect(result).toEqual({endpointPromise: jasmine.any(Promise),
-              applied: true
+              applied: true,
+              awesome: "set it awesome"
             });
           });
 
@@ -159,7 +169,8 @@ describe("RelatedResourceDecorator", function() {
               expect(result).toEqual({
                 thisResource: resource,
                 uriParams: "cheese",
-                applied: true
+                applied: true,
+                awesome: "set it awesome"
               });
             });
           });
@@ -278,7 +289,8 @@ describe("RelatedResourceDecorator", function() {
           expect(returnedEndpoint).toEqual({
             thisResource: resource,
             uriParams: "cheese",
-            applied: true
+            applied: true,
+            awesome: "set it awesome"
           });
         });
       });

--- a/test/integration/RelationshipsTest.js
+++ b/test/integration/RelationshipsTest.js
@@ -1,5 +1,6 @@
 import RL from "../../src/relayer.js"
 import {Module, Injector, Config} from "a1atscript";
+import {TemplatedUrl} from "../../src/relayer/TemplatedUrl.js";
 
 class Chapter extends RL.Resource {
 }
@@ -351,6 +352,14 @@ describe("Loading relationships test", function() {
           section = _section_;
           done();
         });
+      });
+
+      it("should verify relationships present and accessible", function() {
+        expect(section.book().present()).toBe(true);
+        expect(section.chapter().present()).toBe(true);
+        expect(section.paragraphs().present()).toBe(true);
+        expect(section.book().get()).toEqual(jasmine.any(TemplatedUrl));
+        expect(section.paragraphs().get()[0]).toEqual(jasmine.any(Paragraph));
       });
 
       it("should resolve the section", function() {


### PR DESCRIPTION
In production use of relayer, the team found we were having to access a resource's relationships object on a fairly frequent basis, which was not an original goal -- relationships is supposed to be a private API.

This adds some functions for getting and setting relationships.

so if a book had chapters, you can access book.relationships.chapters by saying book.chapters().get() -- this also sidesteps load and promises for an embedded relationship
