### PR TITLE
Modify chained loads to happen asynchronously

### DIFF
--- a/src/relayer/decorators/JsonPropertyDecorator.js
+++ b/src/relayer/decorators/JsonPropertyDecorator.js
@@ -67,11 +67,13 @@ export default class JsonPropertyDecorator extends ResourceDecorator {
       this._endpointFn = function(uriParams = {}){
         // 'this' in here = Endpoint
 
-        var newPromise = this.load().then((resource) => {
-          return loadedDataEndpointFactory(resource.self(),
-            resource,
-            [embeddedPropertyTransformerFactory(path)]);
-        });
+        var newPromise = () => {
+          return this.load().then((resource) => {
+            return loadedDataEndpointFactory(resource.self(),
+              resource,
+              [embeddedPropertyTransformerFactory(path)]);
+          });
+        }
 
         var newEndpoint = promiseEndpointFactory(newPromise);
 

--- a/src/relayer/decorators/RelatedResourceDecorator.js
+++ b/src/relayer/decorators/RelatedResourceDecorator.js
@@ -22,9 +22,11 @@ export default class RelatedResourceDecorator extends ResourceDecorator {
           var endpoint;
           if (!this.relationships[name]) {
             if (recursiveCall == false) {
-              endpoint = promiseEndpointFactory(this.self().load().then((resource) => {
-                return resource[name](uriParams, true);
-              }));
+              endpoint = promiseEndpointFactory(() => {
+                return this.self().load().then((resource) => {
+                  return resource[name](uriParams, true);
+                })
+              });
             } else {
               throw "Error: Unable to find relationship, even on canonical resource";
             }
@@ -83,15 +85,17 @@ export default class RelatedResourceDecorator extends ResourceDecorator {
       this._endpointFn = function(uriParams = {}){
         // 'this' in here = Endpoint
 
-        var newPromise = this.load().then((resource) => {
-          if (relationship.async) {
-            return resource[name](uriParams);
-          } else {
-            var endpoint = relationship.embeddedEndpoint(resource, uriParams);
-            description.applyToEndpoint(endpoint);
-            return endpoint;
-          }
-        });
+        var newPromise = () => {
+          return this.load().then((resource) => {
+            if (relationship.async) {
+              return resource[name](uriParams);
+            } else {
+              var endpoint = relationship.embeddedEndpoint(resource, uriParams);
+              description.applyToEndpoint(endpoint);
+              return endpoint;
+            }
+          });
+        }
 
         var newEndpoint = promiseEndpointFactory(newPromise);
 

--- a/src/relayer/endpoints/Endpoint.js
+++ b/src/relayer/endpoints/Endpoint.js
@@ -5,7 +5,7 @@ export default class Endpoint {
   }
 
   create(resource, res, rej){
-    return this.endpointPromise.then((endpoint) => {
+    return this.endpointPromise().then((endpoint) => {
       if (endpoint._create) {
         return endpoint._create(resource);
       } else {
@@ -15,7 +15,7 @@ export default class Endpoint {
   }
 
   update(resource, res, rej){
-    return this.endpointPromise.then((endpoint) => {
+    return this.endpointPromise().then((endpoint) => {
       if (endpoint._update) {
         return endpoint._update(resource);
       } else {
@@ -25,7 +25,7 @@ export default class Endpoint {
   }
 
   load(res, rej){
-    return this.endpointPromise.then((endpoint) => {
+    return this.endpointPromise().then((endpoint) => {
       if (endpoint._load) {
         return endpoint._load();
       } else {
@@ -45,7 +45,7 @@ export default class Endpoint {
   }
 
   remove(res, rej){
-    return this.endpointPromise.then((endpoint) => {
+    return this.endpointPromise().then((endpoint) => {
       return endpoint._remove();
     }).then(res, rej);
   }

--- a/src/relayer/endpoints/PromiseEndpoint.js
+++ b/src/relayer/endpoints/PromiseEndpoint.js
@@ -4,9 +4,9 @@ import {SimpleFactory} from "../SimpleFactoryInjector.js";
 @SimpleFactory('PromiseEndpointFactory')
 export default class PromiseEndpoint extends Endpoint {
 
-  constructor(promise) {
+  constructor(promiseFunction) {
     super();
-    this.endpointPromise = promise;
+    this.endpointPromise = promiseFunction;
   }
 
 }

--- a/src/relayer/endpoints/ResolvedEndpoint.js
+++ b/src/relayer/endpoints/ResolvedEndpoint.js
@@ -17,7 +17,7 @@ export default class ResolvedEndpoint extends Endpoint {
     } else {
       this.createResourceTransformers = [createResourceTransformers];
     }
-    this.endpointPromise = Promise.resolve(this);
+    this.endpointPromise = () => { return Promise.resolve(this) };
   }
 
   _load() {

--- a/test/PromiseEndpoint.js
+++ b/test/PromiseEndpoint.js
@@ -78,7 +78,7 @@ describe("PromiseEndpoint", function() {
     resourceTransformerResponseSpy = spyOn(resourceTransformer, "transformResponse").and.callThrough();
 
     resolvedEndpoint = new ResolvedEndpoint(Promise, transport, templatedUrl, resourceTransformer, createResourceTransformer)
-    promiseEndpoint = new PromiseEndpoint(Promise.resolve(resolvedEndpoint));
+    promiseEndpoint = new PromiseEndpoint(function() { return Promise.resolve(resolvedEndpoint) });
 
   });
 

--- a/test/decorators/JsonPropertyDecorator.js
+++ b/test/decorators/JsonPropertyDecorator.js
@@ -128,7 +128,7 @@ describe("JsonPropertyDecorator", function() {
   describe("on endpoint", function() {
     beforeEach(function(done) {
       jsonPropertyDecorator.endpointApply(mockEndpoint);
-      mockEndpoint.awesome().endpointPromise.then((result) => {
+      mockEndpoint.awesome().endpointPromise().then((result) => {
         loadedEndpoint = result;
         done();
       });

--- a/test/decorators/RelatedResourceDecorator.js
+++ b/test/decorators/RelatedResourceDecorator.js
@@ -141,7 +141,7 @@ describe("RelatedResourceDecorator", function() {
 
 
           it("should setup the right endpoint", function() {
-            expect(result).toEqual({endpointPromise: jasmine.any(Promise),
+            expect(result).toEqual({endpointPromise: jasmine.any(Function),
               applied: true
             });
           });
@@ -149,7 +149,7 @@ describe("RelatedResourceDecorator", function() {
           describe("second call resolves", function() {
             beforeEach(function(done) {
               resource.relationships["awesome"] = { value: "is here"};
-              result.endpointPromise.then((resolvedValue) => {
+              result.endpointPromise().then((resolvedValue) => {
                 result = resolvedValue;
                 done();
               });
@@ -166,7 +166,7 @@ describe("RelatedResourceDecorator", function() {
 
           describe("second call still missing", function() {
             beforeEach(function(done) {
-              result.endpointPromise.catch((error) => {
+              result.endpointPromise().catch((error) => {
                 result = error;
                 done();
               });
@@ -261,14 +261,14 @@ describe("RelatedResourceDecorator", function() {
 
       it("should have the right values", function() {
         expect(mockEndpoint.awesome()).toEqual({
-          endpointPromise: jasmine.any(Promise),
+          endpointPromise: jasmine.any(Function),
           applied: true
         });
       });
 
       describe("resolved", function() {
         beforeEach(function(done) {
-          mockEndpoint.awesome("cheese").endpointPromise.then((resolved) => {
+          mockEndpoint.awesome("cheese").endpointPromise().then((resolved) => {
             returnedEndpoint = resolved;
             done();
           });
@@ -292,14 +292,14 @@ describe("RelatedResourceDecorator", function() {
 
       it("should have the right values", function() {
         expect(mockEndpoint.awesome()).toEqual({
-          endpointPromise: jasmine.any(Promise),
+          endpointPromise: jasmine.any(Function),
           applied: true
         });
       });
 
       describe("resolved", function() {
         beforeEach(function(done) {
-          mockEndpoint.awesome("cheese").endpointPromise.then((resolved) => {
+          mockEndpoint.awesome("cheese").endpointPromise().then((resolved) => {
             returnedEndpoint = resolved;
             done();
           });


### PR DESCRIPTION
now when you do

resource.someResource().relatedResource(),

no loads at all happen until you do .load()
