### PR TITLE
denormalize url since it's referenced so often

### DIFF
--- a/src/relayer/TemplatedUrl.js
+++ b/src/relayer/TemplatedUrl.js
@@ -7,6 +7,7 @@ export class TemplatedUrl {
     this._uriTemplate = new UriTemplate(uriTemplate);
     this._uriParams = uriParams;
     this._paths = [];
+    this._url = this._uriTemplate.fillFromObject(this._uriParams);
   }
 
   get uriTemplate() {
@@ -18,12 +19,13 @@ export class TemplatedUrl {
   }
 
   get url() {
-    return this._uriTemplate.fillFromObject(this._uriParams);
+    return this._url
   }
 
   _setUrl(url) {
     var uriParams = this._uriTemplate.fromUri(url);
     this._uriParams = uriParams;
+    this._url = url;
   }
 
   addDataPathLink(resource, path, overwrite = true) {


### PR DESCRIPTION
a small -- we need to watch url's quite often in Yoric since they are essentially the "id" for a resource. Profile testing showed we were spending a lot of time in fetch the url from the template + params, which only change in two specific cases. So instead, this denormalizes the value.
