### PR TITLE
Apply inflection to template name

### DIFF
--- a/src/relayer/relationshipDescriptions/ListRelationshipDescription.js
+++ b/src/relayer/relationshipDescriptions/ListRelationshipDescription.js
@@ -16,7 +16,7 @@ import {SimpleFactory} from "../SimpleFactoryInjector.js";
   'LoadedDataEndpointFactory',
   'TemplatedUrlFromUrlFactory',
   'TemplatedUrlFactory'])
-export default class SingleRelationshipDescription extends RelationshipDescription {
+export default class ListRelationshipDescription extends RelationshipDescription {
   constructor(relationshipInitializerFactory,
     resourceMapperFactory,
     resourceSerializerFactory,
@@ -71,7 +71,11 @@ export default class SingleRelationshipDescription extends RelationshipDescripti
   }
 
   set linkTemplate(linkTemplate) {
-    this._linkTemplatePath = `$.links.${linkTemplate}`;
+    this._linkTemplatePath = `$.links.${this.inflector.underscore(linkTemplate)}`;
+  }
+
+  set linkTemplatePath(linkTemplatePath) {
+    this._linkTemplatePath = linkTemplatePath;
   }
 
   hasParams(uriParams) {

--- a/test/relationshipDescriptions/ListRelationshipDescription.js
+++ b/test/relationshipDescriptions/ListRelationshipDescription.js
@@ -38,8 +38,11 @@ describe("ListRelationshipDescription", function() {
     resourceSerializerFactory = jasmine.createSpy("resourceSerializerFactory");
 
     inflector = {
-      underscore: function(name) {
-        return name;
+      underscore: function(key) {
+        // TODO match the latest logic from Active Support
+        return key.replace(/[A-Z]/g, function (match, index) {
+          return index === 0 ? match : '_' + match.toLowerCase();
+        });
       }
     }
 
@@ -116,12 +119,12 @@ describe("ListRelationshipDescription", function() {
       pathGet(path) {
         if (path == "$.links.awesomes") {
           return "/awesomes";
-        } else if (path == "$.links.awesome") {
+        } else if (path == "$.links.awesome_town") {
           return "/awesomes/{id}";
         }
       }
     }
-    linkTemplate = "awesome";
+    linkTemplate = "awesomeTown";
 
     singleRelationshipDescriptionFactory = function(name, ResourceClass) {
       return {
@@ -173,7 +176,7 @@ describe("ListRelationshipDescription", function() {
     expect(listRelationshipDescription.initialValues).toEqual(initialValues);
     expect(listRelationshipDescription.async).toBe(true);
     expect(listRelationshipDescription.canCreate).toBe(false);
-    expect(listRelationshipDescription._linkTemplatePath).toBe("$.links.awesome");
+    expect(listRelationshipDescription._linkTemplatePath).toBe("$.links.awesome_town");
     expect(listRelationshipDescription.linksPath).toEqual("$.links.awesomes");
     expect(listRelationshipDescription.dataPath).toEqual("$.data.awesomes");
 


### PR DESCRIPTION
Several people were confused when they assumed setting a link template that it needed to be in underscore format. Now it can accept lowerCamel format names.
