### PR TITLE
Single resource templates

### DIFF
--- a/src/relayer/relationshipDescriptions/SingleRelationshipDescription.js
+++ b/src/relayer/relationshipDescriptions/SingleRelationshipDescription.js
@@ -10,7 +10,7 @@ import {SimpleFactory} from "../SimpleFactoryInjector.js";
   'EmbeddedRelationshipTransformerFactory',
   'ResolvedEndpointFactory',
   'LoadedDataEndpointFactory',
-  'TemplatedUrlFromUrlFactory'])
+  'TemplatedUrlFactory'])
 export default class SingleRelationshipDescription extends RelationshipDescription {
   constructor(relationshipInitializerFactory,
     resourceMapperFactory,
@@ -20,7 +20,7 @@ export default class SingleRelationshipDescription extends RelationshipDescripti
     embeddedRelationshipTransformerFactory,
     resolvedEndpointFactory,
     loadedDataEndpointFactory,
-    templatedUrlFromUrlFactory,
+    templatedUrlFactory,
     name,
     ResourceClass,
     initialValues) {
@@ -37,7 +37,7 @@ export default class SingleRelationshipDescription extends RelationshipDescripti
     this.embeddedRelationshipTransformerFactory = embeddedRelationshipTransformerFactory;
     this.resolvedEndpointFactory = resolvedEndpointFactory;
     this.loadedDataEndpointFactory = loadedDataEndpointFactory;
-    this.templatedUrlFromUrlFactory = templatedUrlFromUrlFactory;
+    this.templatedUrlFactory = templatedUrlFactory;
   }
 
   embeddedEndpoint(parent, uriParams) {
@@ -49,7 +49,7 @@ export default class SingleRelationshipDescription extends RelationshipDescripti
   linkedEndpoint(parent, uriParams) {
     var transport = parent.self().transport;
     var url = parent.pathGet(this.linksPath);
-    var templatedUrl = this.templatedUrlFromUrlFactory(url, url);
+    var templatedUrl = this.templatedUrlFactory(url, uriParams || {});
     templatedUrl.addDataPathLink(parent, this.linksPath);
     var primaryResourceTransformer = this.primaryResourceTransformerFactory(this);
     return this.resolvedEndpointFactory(transport, templatedUrl, primaryResourceTransformer);

--- a/src/relayer/relationshipDescriptions/SingleRelationshipDescription.js
+++ b/src/relayer/relationshipDescriptions/SingleRelationshipDescription.js
@@ -38,9 +38,21 @@ export default class SingleRelationshipDescription extends RelationshipDescripti
     this.resolvedEndpointFactory = resolvedEndpointFactory;
     this.loadedDataEndpointFactory = loadedDataEndpointFactory;
     this.templatedUrlFactory = templatedUrlFactory;
+    this._templated = false;
+  }
+
+  set templated(templated) {
+    this._templated = templated;
+  }
+
+  get templated() {
+    return this._templated;
   }
 
   embeddedEndpoint(parent, uriParams) {
+    if (this._templated) {
+      throw "A templated hasOne relationship cannot be embedded";
+    }
     var parentEndpoint = parent.self();
     var embeddedRelationshipTransformer = this.embeddedRelationshipTransformerFactory(this.name);
     return this.loadedDataEndpointFactory(parentEndpoint, parent, embeddedRelationshipTransformer);
@@ -49,8 +61,11 @@ export default class SingleRelationshipDescription extends RelationshipDescripti
   linkedEndpoint(parent, uriParams) {
     var transport = parent.self().transport;
     var url = parent.pathGet(this.linksPath);
-    var templatedUrl = this.templatedUrlFactory(url, uriParams || {});
-    templatedUrl.addDataPathLink(parent, this.linksPath);
+    var params = this._templated ? uriParams : {};
+    var templatedUrl = this.templatedUrlFactory(url, params);
+    if (!this._templated) {
+      templatedUrl.addDataPathLink(parent, this.linksPath);
+    }
     var primaryResourceTransformer = this.primaryResourceTransformerFactory(this);
     return this.resolvedEndpointFactory(transport, templatedUrl, primaryResourceTransformer);
   }

--- a/test/integration/RelationshipsTest.js
+++ b/test/integration/RelationshipsTest.js
@@ -90,6 +90,14 @@ RL.Describe(Book, (desc) => {
   characters.canCreate = true;
 });
 
+class BookSigning extends RL.Resource {
+
+}
+
+RL.Describe(BookSigning, (desc) => {
+  desc.property("date", "");
+});
+
 class Resources extends RL.Resource {
 }
 
@@ -97,6 +105,7 @@ RL.Describe(Resources, (desc) => {
   var books = desc.hasList("books", Book, [])
   books.linkTemplate = "book";
   books.canCreate = true;
+  desc.hasOne("bookSigning", BookSigning)
 });
 
 // this is horrible -- no easy way to get Babel and Traceur to compile the same config block
@@ -141,7 +150,8 @@ describe("Loading relationships test", function() {
             data: {},
             links: {
               books: "/books",
-              book: "/books/{id}"
+              book: "/books/{id}",
+              book_signing: "/book_signings/{id}"
             }
           }
         });
@@ -411,6 +421,22 @@ describe("Loading relationships test", function() {
             ]
           }
         });
+      } else if (params.url == "http://www.example.com/book_signings/2") {
+        return Promise.resolve({
+          status: 200,
+          headers() {
+            return {
+              ETag: "77777"
+            }
+          },
+          data: {
+            links: {
+            },
+            data: {
+              date: "a day"
+            }
+          }
+        });
       }
     }
     angular.mock.module(function($provide) {
@@ -516,5 +542,21 @@ describe("Loading relationships test", function() {
         expect(sectionGroup[0].title).toEqual("Hey man there's a beverage here")
       })
     })
+  });
+
+  describe("book signing", function() {
+    var bookSigning;
+
+    beforeEach(function(done) {
+      resources.bookSigning({id: 2}).load().then((_bookSigning_) => {
+        bookSigning = _bookSigning_;
+        done();
+      });
+      $rootScope.$apply();
+    });
+
+    it("can load a single relationship from a template url", function() {
+      expect(bookSigning.date).toEqual("a day");
+    });
   });
 });

--- a/test/integration/RelationshipsTest.js
+++ b/test/integration/RelationshipsTest.js
@@ -105,7 +105,8 @@ RL.Describe(Resources, (desc) => {
   var books = desc.hasList("books", Book, [])
   books.linkTemplate = "book";
   books.canCreate = true;
-  desc.hasOne("bookSigning", BookSigning)
+  var bookSigning = desc.hasOne("bookSigning", BookSigning)
+  bookSigning.templated = true;
 });
 
 // this is horrible -- no easy way to get Babel and Traceur to compile the same config block

--- a/test/relationshipDescriptions/SingleRelationshipDescription.js
+++ b/test/relationshipDescriptions/SingleRelationshipDescription.js
@@ -9,7 +9,7 @@ describe("SingleRelationshipDescription", function() {
     embeddedRelationshipTransformerFactory,
     resolvedEndpointFactory,
     loadedDataEndpointFactory,
-    templatedUrlFromUrlFactory,
+    templatedUrlFactory,
     name,
     ResourceClass,
     initialValues,
@@ -56,9 +56,9 @@ describe("SingleRelationshipDescription", function() {
         return { endpoint, resource, transformers};
       });
 
-    templatedUrlFromUrlFactory = jasmine.createSpy("templatedUrlFromUrlFactory").and.callFake(
-      function(uriTemplate, url) {
-        return { uriTemplate, url,
+    templatedUrlFactory = jasmine.createSpy("templatedUrlFactory").and.callFake(
+      function(uriTemplate, uriParams) {
+        return { uriTemplate, uriParams,
           addDataPathLink(resource, path) {
             this.dataPath = { resource, path }
           }
@@ -98,7 +98,7 @@ describe("SingleRelationshipDescription", function() {
       embeddedRelationshipTransformerFactory,
       resolvedEndpointFactory,
       loadedDataEndpointFactory,
-      templatedUrlFromUrlFactory,
+      templatedUrlFactory,
       name,
       ResourceClass,
       initialValues);
@@ -115,7 +115,7 @@ describe("SingleRelationshipDescription", function() {
     expect(singleRelationshipDescription.embeddedRelationshipTransformerFactory).toEqual(embeddedRelationshipTransformerFactory);
     expect(singleRelationshipDescription.resolvedEndpointFactory).toEqual(resolvedEndpointFactory);
     expect(singleRelationshipDescription.loadedDataEndpointFactory).toEqual(loadedDataEndpointFactory);
-    expect(singleRelationshipDescription.templatedUrlFromUrlFactory).toEqual(templatedUrlFromUrlFactory);
+    expect(singleRelationshipDescription.templatedUrlFactory).toEqual(templatedUrlFactory);
     expect(singleRelationshipDescription.name).toEqual(name);
     expect(singleRelationshipDescription.ResourceClass).toEqual(ResourceClass);
     expect(singleRelationshipDescription.initialValues).toEqual(initialValues);
@@ -156,7 +156,7 @@ describe("SingleRelationshipDescription", function() {
       expect(linkedEndpoint.transport).toEqual(mockTransport);
       expect(linkedEndpoint.templatedUrl).toEqual({
         uriTemplate: "/awesome",
-        url: "/awesome",
+        uriParams: {},
         addDataPathLink: jasmine.any(Function),
         dataPath: {
           resource: resource,
@@ -170,7 +170,7 @@ describe("SingleRelationshipDescription", function() {
     });
 
     it("should setup the templated url", function() {
-      expect(templatedUrlFromUrlFactory).toHaveBeenCalled();
+      expect(templatedUrlFactory).toHaveBeenCalled();
     })
     it("should setup the right transformer", function() {
       expect(primaryResourceTransformerFactory).toHaveBeenCalled();

--- a/test/relationshipDescriptions/SingleRelationshipDescription.js
+++ b/test/relationshipDescriptions/SingleRelationshipDescription.js
@@ -125,59 +125,112 @@ describe("SingleRelationshipDescription", function() {
   });
 
   describe("embeddedEndpoint", function() {
-    var embeddedEndpoint;
+    describe("standard", function() {
+      var embeddedEndpoint;
 
-    beforeEach(function() {
-      embeddedEndpoint = singleRelationshipDescription.embeddedEndpoint(resource)
-    });
+      beforeEach(function() {
+        embeddedEndpoint = singleRelationshipDescription.embeddedEndpoint(resource)
+      });
 
-    it("should have the right values", function() {
-      expect(embeddedEndpoint.endpoint).toEqual(mockEndpoint);
-      expect(embeddedEndpoint.resource).toEqual(resource);
-      expect(embeddedEndpoint.transformers).toEqual({name: "awesome"});
-    });
+      it("should have the right values", function() {
+        expect(embeddedEndpoint.endpoint).toEqual(mockEndpoint);
+        expect(embeddedEndpoint.resource).toEqual(resource);
+        expect(embeddedEndpoint.transformers).toEqual({name: "awesome"});
+      });
 
-    it("should setup the right transformer", function() {
-      expect(embeddedRelationshipTransformerFactory).toHaveBeenCalled();
-    });
+      it("should setup the right transformer", function() {
+        expect(embeddedRelationshipTransformerFactory).toHaveBeenCalled();
+      });
 
-    it("should setup the right endpoint", function() {
-      expect(loadedDataEndpointFactory).toHaveBeenCalled();
-    });
+      it("should setup the right endpoint", function() {
+        expect(loadedDataEndpointFactory).toHaveBeenCalled();
+      });
+    })
+
+    describe("templated", function() {
+      var error;
+      beforeEach(function() {
+        singleRelationshipDescription.templated = true;
+        try {
+          singleRelationshipDescription.embeddedEndpoint(resource)
+        } catch(err) {
+          error = err;
+        }
+      });
+
+      it("should error because a templated relationship cannot be embedded", function() {
+        expect(error).toEqual("A templated hasOne relationship cannot be embedded")
+      })
+    })
   });
 
   describe("linkedEndpoint", function() {
-    var linkedEndpoint;
-    beforeEach(function() {
-      linkedEndpoint = singleRelationshipDescription.linkedEndpoint(resource)
-    });
-
-    it("should have the right values", function() {
-      expect(linkedEndpoint.transport).toEqual(mockTransport);
-      expect(linkedEndpoint.templatedUrl).toEqual({
-        uriTemplate: "/awesome",
-        uriParams: {},
-        addDataPathLink: jasmine.any(Function),
-        dataPath: {
-          resource: resource,
-          path: "$.links.awesome"
-        }
+    describe("standard", function() {
+      var linkedEndpoint;
+      beforeEach(function() {
+        linkedEndpoint = singleRelationshipDescription.linkedEndpoint(resource)
       });
-      expect(linkedEndpoint.transformers).toEqual(
-        {
-          relationship: singleRelationshipDescription
+
+      it("should have the right values", function() {
+        expect(linkedEndpoint.transport).toEqual(mockTransport);
+        expect(linkedEndpoint.templatedUrl).toEqual({
+          uriTemplate: "/awesome",
+          uriParams: {},
+          addDataPathLink: jasmine.any(Function),
+          dataPath: {
+            resource: resource,
+            path: "$.links.awesome"
+          }
         });
+        expect(linkedEndpoint.transformers).toEqual(
+          {
+            relationship: singleRelationshipDescription
+          });
+      });
+
+      it("should setup the templated url", function() {
+        expect(templatedUrlFactory).toHaveBeenCalled();
+      })
+      it("should setup the right transformer", function() {
+        expect(primaryResourceTransformerFactory).toHaveBeenCalled();
+      });
+
+      it("should setup the right endpoint", function() {
+        expect(resolvedEndpointFactory).toHaveBeenCalled();
+      });
     });
 
-    it("should setup the templated url", function() {
-      expect(templatedUrlFactory).toHaveBeenCalled();
-    })
-    it("should setup the right transformer", function() {
-      expect(primaryResourceTransformerFactory).toHaveBeenCalled();
-    });
+    describe("templated", function() {
+      var linkedEndpoint;
+      beforeEach(function() {
+        singleRelationshipDescription.templated = true
+        linkedEndpoint = singleRelationshipDescription.linkedEndpoint(resource, {id: 4})
+      });
 
-    it("should setup the right endpoint", function() {
-      expect(resolvedEndpointFactory).toHaveBeenCalled();
+      it("should have the right values", function() {
+        expect(linkedEndpoint.transport).toEqual(mockTransport);
+        expect(linkedEndpoint.templatedUrl).toEqual({
+          uriTemplate: "/awesome",
+          uriParams: {id: 4},
+          addDataPathLink: jasmine.any(Function),
+        });
+        expect(linkedEndpoint.transformers).toEqual(
+          {
+            relationship: singleRelationshipDescription
+          });
+      });
+
+      it("should setup the templated url", function() {
+        expect(templatedUrlFactory).toHaveBeenCalledWith("/awesome", {id: 4});
+      })
+
+      it("should setup the right transformer", function() {
+        expect(primaryResourceTransformerFactory).toHaveBeenCalled();
+      });
+
+      it("should setup the right endpoint", function() {
+        expect(resolvedEndpointFactory).toHaveBeenCalled();
+      });
     });
   });
 });


### PR DESCRIPTION
I've found several cases where I want to look up a uri-templated resource without having it attached to an entire list resource.

This allows you to do a hasOne relationship and then set templated = true on it, which means it is assumed to be a linked resource (as opposed to embedded) and you can pass uri params to it to look up a specific instance of that resource.

There's a specific need for this for converting over some aspects of the CMS, as the /admin/menus index action returns a very different type of resource than the /admin/menus/:id show action.
